### PR TITLE
Disable initial iCloud popup window too.

### DIFF
--- a/ClearReg/Makefile
+++ b/ClearReg/Makefile
@@ -6,8 +6,9 @@ PACKAGE_NAME=ClearReg
 REVERSE_DOMAIN=com.grahamgilbert
 PAYLOAD=\
 	pack-AppleSetupDone \
-	pack-SetupRegComplete
-    
+	pack-SetupRegComplete \
+	pack-script-postinstall
+
 pack-AppleSetupDone:
 	@sudo mkdir -p ${WORK_D}/var/db/
 	@sudo touch ${WORK_D}/var/db/.AppleSetupDone

--- a/ClearReg/postinstall
+++ b/ClearReg/postinstall
@@ -1,0 +1,49 @@
+#!/bin/sh
+
+# Determine OS version && OS build number
+osvers=$(sw_vers -productVersion | awk -F. '{print $2}')
+sw_vers=$(sw_vers -productVersion)
+sw_build=$(sw_vers -buildVersion)
+
+# Checks first to see if the Mac is running 10.7.0 or higher. 
+# If so, the script checks the system default user template
+# for the presence of the Library/Preferences directory. Once
+# found, the iCloud and Diagnostic pop-up settings are set 
+# to be disabled.
+if [[ ${osvers} -ge 7 ]]; then
+
+ for USER_TEMPLATE in "/System/Library/User Template"/*
+  do
+    /usr/bin/defaults write "${USER_TEMPLATE}"/Library/Preferences/com.apple.SetupAssistant DidSeeCloudSetup -bool true
+    /usr/bin/defaults write "${USER_TEMPLATE}"/Library/Preferences/com.apple.SetupAssistant GestureMovieSeen none
+    /usr/bin/defaults write "${USER_TEMPLATE}"/Library/Preferences/com.apple.SetupAssistant LastSeenCloudProductVersion "${sw_vers}"
+    /usr/bin/defaults write "${USER_TEMPLATE}"/Library/Preferences/com.apple.SetupAssistant LastSeenBuddyBuildVersion "${sw_build}"      
+  done
+  
+ # Checks first to see if the Mac is running 10.7.0 or higher.
+ # If so, the script checks the existing user folders in /Users
+ # for the presence of the Library/Preferences directory.
+ #
+ # If the directory is not found, it is created and then the
+ # iCloud and Diagnostic pop-up settings are set to be disabled.
+ for USER_HOME in "/Users"/*
+  do
+    USER_UID=`basename "${USER_HOME}"`
+    if [ ! "${USER_UID}" = "Shared" ]; then
+      if [ ! -d "${USER_HOME}"/Library/Preferences ]; then
+        /bin/mkdir -p "${USER_HOME}"/Library/Preferences
+        /usr/sbin/chown "${USER_UID}" "${USER_HOME}"/Library
+        /usr/sbin/chown "${USER_UID}" "${USER_HOME}"/Library/Preferences
+      fi
+      if [ -d "${USER_HOME}"/Library/Preferences ]; then
+        /usr/bin/defaults write "${USER_HOME}"/Library/Preferences/com.apple.SetupAssistant DidSeeCloudSetup -bool true
+        /usr/bin/defaults write "${USER_HOME}"/Library/Preferences/com.apple.SetupAssistant GestureMovieSeen none
+        /usr/bin/defaults write "${USER_HOME}"/Library/Preferences/com.apple.SetupAssistant LastSeenCloudProductVersion "${sw_vers}"
+        /usr/bin/defaults write "${USER_HOME}"/Library/Preferences/com.apple.SetupAssistant LastSeenBuddyBuildVersion "${sw_build}"
+        /usr/sbin/chown "${USER_UID}" "${USER_HOME}"/Library/Preferences/com.apple.SetupAssistant.plist
+      fi
+    fi
+  done
+fi
+
+exit 0


### PR DESCRIPTION
I wanted to bypass every setup window that appears at first boot. Credits for the [script](https://github.com/rtrouton/rtrouton_scripts/blob/master/rtrouton_scripts/first_boot/10.9/first_boot.sh) goes to Rich Trouton!