### PR TITLE
Allow set_desktops.py to set multiple desktop wallpapers, and use Munki's Python3

### DIFF
--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
  
 '''Uses Cocoa classes via PyObjC to set a desktop picture on all screens.
 Tested on Mountain Lion and Mavericks. Inspired by Greg Neagle's work: https://gist.github.com/gregneagle/6957826

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -1,16 +1,16 @@
-#!/usr/bin/python3
- 
+#!/usr/local/munki/munki-python
+
 '''Uses Cocoa classes via PyObjC to set a desktop picture on all screens.
 Tested on Mountain Lion and Mavericks. Inspired by Greg Neagle's work: https://gist.github.com/gregneagle/6957826
- 
+
 See:
 https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/classes/NSWorkspace_Class/Reference/Reference.html
- 
+
 https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Classes/NSURL_Class/Reference/Reference.html
- 
+
 https://developer.apple.com/library/mac/documentation/cocoa/reference/applicationkit/classes/NSScreen_Class/Reference/Reference.html
 '''
- 
+
 from AppKit import NSWorkspace, NSScreen
 from Foundation import NSURL
 import argparse
@@ -19,25 +19,26 @@ import sys
 parser = argparse.ArgumentParser(description='Sets the desktop picture on all screens')
 parser.add_argument('--path', help='The path of the image')
 args = vars(parser.parse_args())
- 
+
 if args['path']:
     picture_path = args['path']
 else:
     print >> sys.stderr, 'You must supply a path for the desktop picture'
     exit(-1)
- 
+
 # generate a fileURL for the desktop picture
 file_url = NSURL.fileURLWithPath_(picture_path)
- 
+
 # make image options dictionary
 # we just make an empty one because the defaults are fine
 options = {}
- 
+
 # get shared workspace
 ws = NSWorkspace.sharedWorkspace()
- 
+
 # iterate over all screens
 for screen in NSScreen.screens():
+    print(screen)
     # tell the workspace to set the desktop picture
     (result, error) = ws.setDesktopImageURL_forScreen_options_error_(
                 file_url, screen, options, None)

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -18,6 +18,7 @@ import sys
 
 parser = argparse.ArgumentParser(description='Sets the desktop picture on all screens')
 parser.add_argument('--path', help='The path of the image')
+parser.add_argument('--secondpath', help='The path of second image')
 args = vars(parser.parse_args())
 
 if args['path']:
@@ -25,6 +26,10 @@ if args['path']:
 else:
     print >> sys.stderr, 'You must supply a path for the desktop picture'
     exit(-1)
+if args['secondpath']:
+    picture2_path = args['secondpath']
+else:
+    picture2_path = None
 
 # generate a fileURL for the desktop picture
 file_url = NSURL.fileURLWithPath_(picture_path)

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -45,7 +45,7 @@ ws = NSWorkspace.sharedWorkspace()
 screen_counter = 0
 
 # iterate over all screens
-while counter < len(NSScreen.screens():
+while counter < len(NSScreen.screens()):
     if counter > len(picture_paths):
         picture_counter = 0
     else:

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -19,20 +19,20 @@ import sys
 parser = argparse.ArgumentParser(description='Sets the desktop picture on all screens')
 parser.add_argument('--path', help='The path of the image')
 parser.add_argument('--secondpath', help='The path of second image')
+parser.add_argument('--thirdpath', help='The path of third image')
 args = vars(parser.parse_args())
 
+picture_paths = []
+
 if args['path']:
-    picture_path = args['path']
+    picture_paths.append(args['path'])
 else:
     print >> sys.stderr, 'You must supply a path for the desktop picture'
     exit(-1)
 if args['secondpath']:
-    picture2_path = args['secondpath']
-else:
-    picture2_path = None
-
-# generate a fileURL for the desktop picture
-file_url = NSURL.fileURLWithPath_(picture_path)
+    picture_paths.append(args['secondpath'])
+if args['thirdpath']:
+    picture_paths.append(args['thirdpath'])
 
 # make image options dictionary
 # we just make an empty one because the defaults are fine
@@ -41,12 +41,23 @@ options = {}
 # get shared workspace
 ws = NSWorkspace.sharedWorkspace()
 
+# Initialize screen counter
+screen_counter = 0
+
 # iterate over all screens
-for screen in NSScreen.screens():
-    print(screen)
+while counter < len(NSScreen.screens():
+    if counter > len(picture_paths):
+        picture_counter = 0
+    else:
+        picture_counter = screen_counter
+    # generate a fileURL for the desktop picture
+    file_url = NSURL.fileURLWithPath_(picture_paths[picture_counter])
+    print(f"Setting screen {screen_counter} to {picture_paths[picture_counter]}")
     # tell the workspace to set the desktop picture
     (result, error) = ws.setDesktopImageURL_forScreen_options_error_(
-                file_url, screen, options, None)
+                file_url, NSScreen.screens[screen_counter], options, None)
     if error:
         print error
         exit(-1)
+    screen_counter += 1
+

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -45,8 +45,8 @@ ws = NSWorkspace.sharedWorkspace()
 screen_counter = 0
 
 # iterate over all screens
-while counter < len(NSScreen.screens()):
-    if counter > len(picture_paths):
+while screen_counter < len(NSScreen.screens()):
+    if screen_counter > len(picture_paths):
         picture_counter = 0
     else:
         picture_counter = screen_counter

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -45,7 +45,7 @@ ws = NSWorkspace.sharedWorkspace()
 screen_counter = 0
 
 # iterate over all screens
-while screen_counter < len(NSScreen.screens()):
+for screen in NSScreen.screens():
     if screen_counter > len(picture_paths):
         picture_counter = 0
     else:
@@ -55,9 +55,8 @@ while screen_counter < len(NSScreen.screens()):
     print(f"Setting screen {screen_counter} to {picture_paths[picture_counter]}")
     # tell the workspace to set the desktop picture
     (result, error) = ws.setDesktopImageURL_forScreen_options_error_(
-                file_url, NSScreen.screens[screen_counter], options, None)
+                file_url, screen, options, None)
     if error:
         print(error)
         exit(-1)
     screen_counter += 1
-

--- a/set_desktops/set_desktops.py
+++ b/set_desktops/set_desktops.py
@@ -57,7 +57,7 @@ while counter < len(NSScreen.screens()):
     (result, error) = ws.setDesktopImageURL_forScreen_options_error_(
                 file_url, NSScreen.screens[screen_counter], options, None)
     if error:
-        print error
+        print(error)
         exit(-1)
     screen_counter += 1
 


### PR DESCRIPTION
As currently written, the `set_desktops.py` script uses a version of Python 2 (`/usr/bin/python`) that Apple removed in macOS 12.3. This PR sets the shebang to be `/usr/local/munki/munki-python`, which seems to work as is (with `/usr/bin/python3`, you'd have to `pip3 install` some missing modules).

This PR also allows for additional arguments of `--secondpath` and `--thirdpath`, in case there are up to two external monitors connected when the script runs.